### PR TITLE
changed hover color according to hover colors of other hyperlinks

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -528,13 +528,14 @@ ul > li > span > i {
   margin-right: 12px;
 }
 .footer-col .social-links a:hover {
-  color: #49c9f8;
+  color: #24262b;
+  background-color: #ffffff;
  
 }
 
 .footer-col .infor ul>li>span:hover{
-	color: #49c9f8;
-  background-color: #192E3A;
+	color:#24262b;
+  background-color: white;
 	
 }
 


### PR DESCRIPTION
Fixes issue #226 
Changed the hover background color to how it is being done for other hyperlinks to keep similarity.

Initially, it was looking like this
![Screenshot (497)_LI](https://user-images.githubusercontent.com/71266173/161730570-68fad7ff-666c-4bb2-bbc0-ea1890b879d1.jpg)
![Screenshot (498)_LI](https://user-images.githubusercontent.com/71266173/161730603-e63debac-1c4f-47fd-b34d-44472cb80faf.jpg)

After updating, it's looking like this
![Screenshot (494)_LI](https://user-images.githubusercontent.com/71266173/161730737-4edd56a7-4e0d-47e6-9e55-b4b5fa05ef02.jpg)
![Screenshot (495)_LI](https://user-images.githubusercontent.com/71266173/161730760-4d75813e-aa79-4881-9c80-c5491208256b.jpg)

