### PR TITLE
fix for intro section and h1 text

### DIFF
--- a/Course/Courses.html
+++ b/Course/Courses.html
@@ -180,13 +180,14 @@
     <!--navbar end here-->
 
 
-    <main style="margin-left: 0% ;">
+    <main style="margin-left: 0%; padding-top:5%">
         <div class="big-wrapper light">
 
 
         <section class="intro">
             <div>
-                <h1 style="color:var(--darkOne); font-size: 5.5rem !important;">
+                <h1 style="color:var(--darkOne); font-size: 5rem !important; text-align: center; word-spacing: .45em;
+                ">
                     Your Course To Success
                 </h1>
                 <p style="font-size: 1.8rem; color:var(--darkOne);">"Wisdom is not a product of schooling but of the lifelong attempt to acquire it."<br/><br> As Earl Nightingale once said: One hour per day of study will put you at the top of your field within three years.


### PR DESCRIPTION
<!-- Remove this section if not applicable -->

## 🛠️ Fixes Issue

- Intro section hidden by navbar
- h1 tag word-spacing too large

## 👨‍💻 Changes proposed
### Before

<img width="960" alt="section-nav" src="https://user-images.githubusercontent.com/16004421/198031272-72a60d30-4c01-41d1-b0fb-9b72610060df.PNG">

### After
<img width="949" alt="fixed_intro_section" src="https://user-images.githubusercontent.com/16004421/198030875-6cc30a7e-fb06-4b96-8a46-67392f8774bd.PNG">

